### PR TITLE
Removed `copy-resources` targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -163,7 +163,10 @@ SET(STB_SRC
     src/stb/stb_image.h
 )
 
-FILE(GLOB_RECURSE RESOURCES RELATIVE ${CMAKE_SOURCE_DIR} "Resources/*")
+FILE(RELATIVE_PATH RESOURCES_DIR "${CMAKE_BINARY_DIR}" "${CMAKE_SOURCE_DIR}/resources")
+ADD_DEFINITIONS(-DRESOURCES_DIR="${RESOURCES_DIR}/")
+
+FILE(GLOB_RECURSE RESOURCES RELATIVE ${CMAKE_SOURCE_DIR} "resources/*")
 FOREACH(res IN ITEMS ${RESOURCES})
     GET_FILENAME_COMPONENT(path "${res}" DIRECTORY)
     FILE(TO_NATIVE_PATH ${path} path)
@@ -241,21 +244,6 @@ ADD_CUSTOM_TARGET(
 )
 SET_TARGET_PROPERTIES(
     run
-    PROPERTIES FOLDER "Automation"
-)
-
-# Copy resources to build directory
-ADD_CUSTOM_TARGET(copy-resources ALL)
-ADD_DEPENDENCIES(${PROJECT_NAME} copy-resources)
-ADD_CUSTOM_COMMAND(
-    OUTPUT
-    TARGET copy-resources PRE_BUILD
-    COMMAND ${CMAKE_COMMAND} -E
-        copy_directory ${CMAKE_SOURCE_DIR}/resources ${CMAKE_BINARY_DIR}/resources
-)
-
-SET_TARGET_PROPERTIES(
-    copy-resources
     PROPERTIES FOLDER "Automation"
 )
 

--- a/demos/HelloWorld/src/GameScene.cpp
+++ b/demos/HelloWorld/src/GameScene.cpp
@@ -21,16 +21,16 @@ void GameScene::Start()
 
 	// Object setup
 	// Primitive Objs
-	_mGameObjects.emplace("Plane", Utils::LoadObj("resources/models/Primitives/pPlane.obj"));
-	_mGameObjects.emplace("Sphere", Utils::LoadObj("resources/models/Primitives/pSphere.obj"));
+	_mGameObjects.emplace("Plane", Utils::LoadObj("models/Primitives/pPlane.obj"));
+	_mGameObjects.emplace("Sphere", Utils::LoadObj("models/Primitives/pSphere.obj"));
 	//_mGameObjects.emplace("Torus", Utils::LoadObj("resources/models/Primitives/pTorus.obj"));
 
 	// Scene Objs
-	_mGameObjects.emplace("Sun", Utils::LoadObj("resources/models/sun.obj"));
-	_mGameObjects.emplace("Earth", Utils::LoadObj("resources/models/earth.obj"));
-	_mGameObjects.emplace("Cube", Utils::LoadObj("resources/models/Primitives/pCube.obj"));
+	_mGameObjects.emplace("Sun", Utils::LoadObj("models/sun.obj"));
+	_mGameObjects.emplace("Earth", Utils::LoadObj("models/earth.obj"));
+	_mGameObjects.emplace("Cube", Utils::LoadObj("models/Primitives/pCube.obj"));
 
-	
+
 	// Initialize Objs
 	//_mGameObjects["Torus"]->SetPosition(glm::vec3(0.0f, 0.0f, 0.0f));
 	//_mGameObjects["Torus"]->SetScale(glm::vec3(1.0f, 1.0f, 1.0f));
@@ -75,19 +75,19 @@ void GameScene::SetupShaders()
 	// Shaders
 	_mNumShaders = 5;
 	std::vector<std::string> vertShaders = {
-		"resources/shaders/axis.vert",
-		"resources/shaders/passThru.vert",
-		"resources/shaders/basicLighting.vert",
-		"resources/shaders/bpLighting.vert",
-		"resources/shaders/nmLighting.vert",
+		"shaders/axis.vert",
+		"shaders/passThru.vert",
+		"shaders/basicLighting.vert",
+		"shaders/bpLighting.vert",
+		"shaders/nmLighting.vert",
 	};
 
 	std::vector<std::string> fragShaders = {
-		"resources/shaders/axis.frag",
-		"resources/shaders/passThru.frag",
-		"resources/shaders/basicLighting.frag",
-		"resources/shaders/bpLighting.frag",
-		"resources/shaders/nmLighting.frag",
+		"shaders/axis.frag",
+		"shaders/passThru.frag",
+		"shaders/basicLighting.frag",
+		"shaders/bpLighting.frag",
+		"shaders/nmLighting.frag",
 	};
 
 	for (int i = 0; i < _mNumShaders; i++)

--- a/src/Shader.cpp
+++ b/src/Shader.cpp
@@ -13,6 +13,9 @@ void Shader::CheckAttribs()
 
 void Shader::SetupShaders(std::string vertFilename, std::string fragFilename)
 {
+	vertFilename = std::string(RESOURCES_DIR) + vertFilename;
+	fragFilename = std::string(RESOURCES_DIR) + fragFilename;
+
     // Load Shaders
     // Retrieve the vertex/fragment source code from filePath
     std::string   vertexCode, fragmentCode;

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -8,6 +8,8 @@ namespace Utils
 {
 	unsigned char* LoadPng(std::string filename, int& w, int& h, int& bpp)
 	{
+		filename = std::string(RESOURCES_DIR) + filename;
+
 		// Remember to call stbi_image_free(image) after using the image and before another.
 		// bpp - bits per pixel
 		// 32 = RGBA = 4 * 8
@@ -23,6 +25,8 @@ namespace Utils
 
 	GLuint LoadTexture(std::string filename)
 	{
+		filename = std::string(RESOURCES_DIR) + filename;
+
 		GLuint texture;
 
 		glGenTextures(1, &texture);
@@ -73,6 +77,8 @@ namespace Utils
 
 	GameObject* LoadObj(std::string filename)
 	{
+		filename = std::string(RESOURCES_DIR) + filename;
+		
 		Assimp::Importer importer;
 		const aiScene* scene = importer.ReadFile(filename,
 			aiProcess_CalcTangentSpace |


### PR DESCRIPTION
Added CMake defined RESOURCES_DIR prefix, prepended to all resource filenames